### PR TITLE
Fixed #23 Module mysql-connection-manager is deprecated

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "morgan": "^1.6.1",
     "multer": "^1.1.0",
     "mysql": "latest",
-    "mysql-connection-manager": "0.0.13",
     "neo-async": "^1.7.4",
     "nunjucks": "^2.4.0",
     "passport": "^0.3.2",


### PR DESCRIPTION
## #23

mysql-connection-manager 모듈을 mysql 모듈의 pooling connection을 이용하여 대체하고,

package.json에서 mysql-connection-manager을 삭제했습니다.
