### PR TITLE
Added chatting module to simplestrap theme.

### DIFF
--- a/app/plain/menu.js
+++ b/app/plain/menu.js
@@ -25,7 +25,7 @@ var Menu = [
         id: 'chatting',
         name: '채팅',
         logged: -1,
-        url: routeTable.chatting_root
+        url: routeTable.chatting
     },
     {
         id: 'professional',

--- a/app/simplestrap/menu.js
+++ b/app/simplestrap/menu.js
@@ -42,6 +42,10 @@ var Menu = [
         name: '로그아웃',
         logged: 1,
         url: routeTable.account_root + routeTable.account.signOut
+    },
+    {
+        name: '채팅',
+        url: routeTable.chatting
     }
 ];
 

--- a/app/simplestrap/route.js
+++ b/app/simplestrap/route.js
@@ -10,6 +10,7 @@ var Account = require('../../module/account');
 var Guestbook = require('../../module/guestbook');
 var Teamblog = require('../../module/teamblog');
 var Editor = require('../../module/editor');
+var Chatting = require('../../module/chatting');
 
 // load own template
 var page = require('./page');
@@ -28,6 +29,7 @@ router.all(routeTable.root, [middleware.test1, middleware.test2], page.indexPage
 // bind static page
 // router.get(routeTable.root, [middleware.test1, middleware.test2], Site.page.index);
 router.get(routeTable.about, Site.plain);
+router.get(routeTable.chatting, Site.plain);
 
 // bind module
 router.use(routeTable.account_root, Account.route);

--- a/core/config/route_default.json
+++ b/core/config/route_default.json
@@ -40,7 +40,7 @@
     "message": "/register",
     "reply": "/register/reply"
   },
-  "chatting_root": "/chatting",
+  "chatting": "/chatting",
   "teamblog_root": "/blog",
   "teamblog": {
     "list": "/",

--- a/core/lib/misc.js
+++ b/core/lib/misc.js
@@ -74,7 +74,7 @@ function getRouteTable() {
             "message": "/register",
             "reply": "/register/reply"
         },
-        "chatting_root": "/chatting",
+        "chatting": "/chatting",
         "teamblog_root": "/blog",
         "teamblog": {
             "list": "/",

--- a/module/account/lib/account.js
+++ b/module/account/lib/account.js
@@ -208,9 +208,7 @@ function registerSimpleForTest(req, res) {
     req.sanitize('nickname').escape();
     req.sanitize('password').trim();
 
-
     findAuthByUserID(req.body.email, function (err, account) {
-
         if (account) {
             req.flash('error', {msg: '이미 존재하는 계정입니다.'});
             return res.redirect('back');

--- a/module/chatting/route.js
+++ b/module/chatting/route.js
@@ -3,10 +3,12 @@ var express = require('express');
 var misc = require('../../core/lib/misc');
 
 var chatting = require('./lib/chatting');
-
+var middleware = require('./lib/middleware');
 var router = express.Router();
 var routeTable = misc.getRouteTable();
 
-router.get(routeTable.chatting_root, chatting.index);
+router.use(middleware.exposeLocals);
+
+router.get(routeTable.chatting, chatting.index);
 
 module.exports = router;

--- a/theme/plain/page/chatting.html
+++ b/theme/plain/page/chatting.html
@@ -6,7 +6,6 @@
     {% include '../include/style.html' %}
     <style>
         * { margin: 0; padding: 0; box-sizing: border-box; }
-        body { font: 13px Helvetica, Arial; }
         form { background: #000; padding: 3px; position: fixed; bottom: 0; width: 100%; }
         form input { border: 0; padding: 10px; width: 90%; margin-right: .5%; }
         form button { width: 9%; background: rgb(130, 224, 255); border: none; padding: 10px; }
@@ -14,7 +13,7 @@
             float: left;
             width: 85%;
             list-style-type: none;
-            margin: 50px 0 0;
+            margin: 62px 0 0;
             padding: 0; }
         #messages li { padding: 5px 10px; }
         #messages li:nth-child(odd) { background: #eee; }
@@ -22,7 +21,7 @@
             float: right;
             width: 15%;
             list-style-type: none;
-            margin: 50px 0 0;
+            margin: 62px 0 0;
             padding: 0; }
         #user-list li { padding: 5px 10px; }
         .footer {

--- a/theme/plain/page/index.html
+++ b/theme/plain/page/index.html
@@ -94,10 +94,8 @@
             <div class="l-box-lrg pure-u-1 pure-u-md-2-5">
                 <form class="pure-form pure-form-stacked sign-up" action="{{ site.root }}{{ route.account_root + route.account.registerSimple }}" method="post">
                     <fieldset>
-
                         <label for="nickname">아이디 <small>화면에 보이는 이름입니다</small></label>
                         <input id="nickname" name="nickname" type="text" placeholder="Your Name">
-
 
                         <label for="email">이메일 <small>고유한 계정이 되는 아이디입니다</small></label>
                         <input id="email" name="email" type="email" placeholder="Your Email">

--- a/theme/simplestrap/page/about.html
+++ b/theme/simplestrap/page/about.html
@@ -24,7 +24,7 @@
                 <code>OLD STYLE WEB SITE TEMPLATE for DEVELOPERS and WEB AGENCIES</code>
             </p>
             <br>
-            <p>블리티터는 다른 솔루션에 비해 다음과 같은 장접을 가지고 있습니다.</p>
+            <p>블리티터는 다른 솔루션에 비해 다음과 같은 장점을 가지고 있습니다.</p>
             <ul>
                 <li>Template <small>적절하게 즉시 사용할 수 있는 다양한 템플릿 을 제공합니다.</small></li>
                 <li>Structure <small>구조 단순해 수정하기 쉽습니다.</small></li>

--- a/theme/simplestrap/page/chatting.html
+++ b/theme/simplestrap/page/chatting.html
@@ -1,0 +1,81 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    {% include './include/header.html' %}
+    <style>
+        * { margin: 0; padding: 0; box-sizing: border-box; }
+        form { background: #000; padding: 3px; position: fixed; bottom: 0; width: 46rem; }
+        form input { border: 0; padding: 10px; width: 90%; margin-right: .5%; }
+        form button { width: 9%; background: rgb(130, 224, 255); border: none; padding: 10px; }
+        #messages {
+            float: left;
+            width: 85%;
+            list-style-type: none;
+            padding: 0; }
+        #messages li { padding: 5px 10px; }
+        #messages li:nth-child(odd) { background: #eee; }
+        #user-list {
+            float: right;
+            width: 15%;
+            list-style-type: none;
+            padding: 0; }
+        #user-list li { padding: 5px 10px; }
+    </style>
+</head>
+<body>
+
+<div class="container">
+    <div class="header clearfix">
+
+        {% include './include/menu.html' %}
+
+    </div>
+
+    {% include './include/flash.html' %}
+    <div class="chatWrapper">
+        <ul id="messages"></ul>
+        <ul id="user-list"></ul>
+        <form action="">
+            <input id="m" autocomplete="off" /><button>Send</button>
+        </form>
+    </div>
+
+</div>
+
+<script src="/lib/jquery/dist/jquery.min.js"></script>
+<script src="/socket.io/socket.io.js"></script>
+<script>
+    var socket = io();
+    $('form').submit(function(){
+        var $m = $('#m');
+        socket.emit('chat message', {msg : $m.val()});
+        $m.val('');
+        return false;
+    });
+
+    function updateUserList(userList) {
+        $('#user-list').text('');
+        for(var user in userList){
+            $('#user-list').append($('<li>').text(user));
+        }
+    }
+
+    socket.on('join', function(data){
+        updateUserList(data)
+    });
+
+    socket.on('leave', function(data){
+        updateUserList(data)
+    });
+
+    socket.on('chat message', function(data){
+        $('#messages').append($('<li>').text(data.nickname + ' : ' + data.msg));
+    });
+</script>
+<!-- Bootstrap core JavaScript
+================================================== -->
+<!-- Placed at the end of the document so the pages load faster -->
+<!-- IE10 viewport hack for Surface/desktop Windows 8 bug -->
+<script src="http://v4-alpha.getbootstrap.com/assets/js/ie10-viewport-bug-workaround.js"></script>
+</body>
+</html>


### PR DESCRIPTION
1. chatting 모듈을 simplestrap 테마에 추가했습니다.
   ![image](https://cloud.githubusercontent.com/assets/11595293/18953887/83d3c3ea-868b-11e6-8105-a7b3477b3981.png)
2. 약간의 레이아웃 문제를 고쳤습니다.
3. chatting 모듈 라우팅을 약간 바꿨습니다. 현재 Plain theme에서는 클라이언트의 app폴더 안의 menu.js의 오브젝트를 가져와서 bindRouter 라는 함수를 통해서 모듈로 라우팅하는 반면에 simplestrap theme에서는 마치 account모듈 처럼 해당 테마의 기본 라우트 함수로 연결되어있습니다.
