### PR TITLE
Fixed #74(로그인시 b_user 테이블의 login_counter, last_logged_at이 업데이트 되지 않는 문제)

### DIFF
--- a/module/account/lib/database.js
+++ b/module/account/lib/database.js
@@ -199,7 +199,7 @@ function selectByUUID(connection, uuid, callback) {
 }
 
 function selectByAuthID(connection, authID, callback) {
-    var field = ['id', 'uuid', 'nickname', 'photo', 'level', 'grant', 'created_at', 'updated_at', 'last_logged_at'];
+    var field = ['id', 'uuid', 'nickname', 'photo', 'level', 'grant', 'created_at', 'updated_at', 'last_logged_at', 'login_counter'];
 
     connection.query(query.selectByAuthID, [field, tables.user, authID], function (err, rows) {
         if (err || !rows) {
@@ -257,7 +257,6 @@ function insertAccount(connection, userData, callback) {
 }
 
 function updateByUUID(connection, userData, UUID, callback) {
-    console.log(tables.user, userData, UUID);
     connection.query(query.updateAccountByUUID, [tables.user, userData, UUID], function (err, result) {
         callback(err, result);
     });

--- a/module/account/lib/passport.js
+++ b/module/account/lib/passport.js
@@ -46,7 +46,7 @@ function authenticate(userID, password, done) {
 }
 
 function serialize(user, done) {
-    winston.verbose('Serialize in process for', user);
+    winston.verbose('Serialize in process for', 'id=', user.id, 'user_id=', user.user_id);
 
     account.findUserByID(user.id, function (error, user) {
         done(error, user.uuid);


### PR DESCRIPTION
## 설명

updateByUUID에서 넘겨받은 userData에 login_counter가 없어서 발생한 문제였습니다.

selectByAuthID의 조회 쿼리에 login_counter를 추가하여 해결했습니다.
