### PR TITLE
Added insert tag code to insertPost methed in teamblog module.

### DIFF
--- a/module/teamblog/lib/teamblog.js
+++ b/module/teamblog/lib/teamblog.js
@@ -166,7 +166,7 @@ function savePost(req, res) {
             res.redirect('back');
         }
 
-        var post_id = result['insertId'];
+        var post_id = result['insertPostId'];
 
         winston.info('Saved post id', post_id);
 

--- a/module/teamblog/route.js
+++ b/module/teamblog/route.js
@@ -21,7 +21,6 @@ router.post(routeTable.teamblog_root + routeTable.teamblog.write, AccountMiddlew
 router.get(routeTable.teamblog_root + routeTable.teamblog.list, teamblog.list);
 router.get(routeTable.teamblog_root + routeTable.teamblog.list + ':page([0-9]+)', teamblog.list);
 router.get(routeTable.teamblog_root + routeTable.teamblog.list + ':year([0-9]+)/:month([0-9]+)', teamblog.list);
-
-router.get(routeTable.teamblog_root + routeTable.teamblog_tag.list + '/:tag', teamblog.list);
+router.get(routeTable.teamblog_root + routeTable.teamblog_tag.list + '/:tag' , teamblog.list);
 
 module.exports = router;

--- a/theme/furion/page/index.html
+++ b/theme/furion/page/index.html
@@ -49,7 +49,7 @@
                             {% if item.tags %}
                             under
                             {% for tag in item.tags %}
-                            <a class="post-category post-category-{{cls.next()}}" href="/tag/{{tag}}">{{tag}}</a>
+                            <a class="post-category post-category-{{cls.next()}}" href="blog/tag/{{tag}}">{{tag}}</a>
                             {% endfor %}
                             {% endif %}
                             <span class="post-date">{{item.created_at}}</span>
@@ -85,7 +85,7 @@
                             {% if item.tags %}
                             under
                             {% for tag in item.tags %}
-                            <a class="post-category post-category-{{cls.next()}}" href="/tag/{{tag}}">{{tag}}</a>
+                            <a class="post-category post-category-{{cls.next()}}" href="blog/tag/{{tag}}">{{tag}}</a>
                             {% endfor %}
                             {% endif %}
                             <span class="post-date">{{item.created_at}}</span>


### PR DESCRIPTION
#76 는 teamblog module에서 블로그의 post list를 보여주는 페이지의 라우팅관련 문제와, 새로 작성한 포스트에서 지정한 태그를 데이터베이스에 저장하지 않는 문제에서 발생한 이슈입니다.

작성된 포스트를 db에 넣을 때 관련 태그들을 적절한 테이블에 같이 삽입하도록 수정했습니다. 이제 태그를 클릭하면 해당 태그를 삽입한 포스트들의 리스트를 보여줍니다.
(코드를 보면 아시겠지만 db에서 가져온 포스트가 아닌, test용으로 하드코딩해놓은 post들에는 링크를 삽입하지 않았습니다.)
